### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,5 +1,8 @@
 name: Tests and build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/alexandrevilain/tabcoder/security/code-scanning/4](https://github.com/alexandrevilain/tabcoder/security/code-scanning/4)

To fix the problem, we should add a `permissions` block to the workflow file, specifying the least privilege required for the jobs. Since none of the jobs in this workflow (lint, test, build) require write access to repository contents, issues, or pull requests, the minimal permission required is `contents: read`. This block can be added at the top level of the workflow (just below the `name:` and before `jobs:`), so it applies to all jobs unless overridden. No additional imports or definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
