### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Publish release on Marketplace
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/alexandrevilain/tabcoder/security/code-scanning/2](https://github.com/alexandrevilain/tabcoder/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow appears to only need to read repository contents (for checkout and possibly for publishing), the minimal permission required is `contents: read`. This block should be added at the top level of the workflow (just after the `name:` line and before `on:`), so it applies to all jobs unless overridden. No changes to the steps or logic are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
